### PR TITLE
Fix(photo viewer close)：写真を閉じるボタンを追加

### DIFF
--- a/lib/presentation/components/common/boul_log.dart
+++ b/lib/presentation/components/common/boul_log.dart
@@ -22,6 +22,7 @@ class BoulLog extends ConsumerStatefulWidget {
   final List<String>? mediaUrls; // 画像がある場合のみ使用される
   final int? tweetId;
   final VoidCallback? onBlockSuccess; // ブロック成功時のコールバック
+  final String? contextPrefix; // Hero tag用のコンテキストプレフィックス
 
   const BoulLog({
     super.key,
@@ -36,6 +37,7 @@ class BoulLog extends ConsumerStatefulWidget {
     this.mediaUrls, // null許容にすることで未添付もOK
     this.tweetId,
     this.onBlockSuccess, // ブロック成功時の処理を親から受け取る
+    this.contextPrefix, // コンテキストを区別するためのプレフィックス
   });
 
   @override
@@ -383,11 +385,11 @@ class _BoulLogState extends ConsumerState<BoulLog> {
                                 context: context,
                                 imageUrls: _imageUrls,
                                 initialIndex: index,
-                                heroTagPrefix: 'boul_log_${widget.userId}_${widget.tweetId}',
+                                heroTagPrefix: '${widget.contextPrefix ?? 'general'}_tweet_media_${widget.userId}_${widget.tweetId}',
                               );
                             },
                             child: Hero(
-                              tag: 'boul_log_${widget.userId}_${widget.tweetId}_$index',
+                              tag: '${widget.contextPrefix ?? 'general'}_tweet_media_${widget.userId}_${widget.tweetId}_$index',
                               child: ClipRRect(
                                 borderRadius: BorderRadius.circular(16),
                                 child: CachedNetworkImage(

--- a/lib/presentation/components/common/image_viewer.dart
+++ b/lib/presentation/components/common/image_viewer.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 /// 画像拡大表示ウィジェット
-/// 
+///
 /// 役割:
 /// - 複数画像の拡大表示とスワイプ機能
 /// - ピンチズーム機能（1.0x - 5.0x）
 /// - Hero アニメーション対応
 /// - タップして閉じる機能
-/// 
+///
 /// クリーンアーキテクチャにおける位置づけ:
 /// - Presentation層のUIコンポーネント
 /// - 再利用可能なウィジェット
@@ -16,10 +16,10 @@ import 'package:cached_network_image/cached_network_image.dart';
 class ImageViewer extends StatelessWidget {
   /// 表示する画像URLのリスト
   final List<String> imageUrls;
-  
+
   /// 初期表示する画像のインデックス
   final int initialIndex;
-  
+
   /// Heroアニメーション用のタグプレフィックス
   final String heroTagPrefix;
 
@@ -31,7 +31,7 @@ class ImageViewer extends StatelessWidget {
   });
 
   /// 画像拡大表示ダイアログを表示
-  /// 
+  ///
   /// [context] ビルドコンテキスト
   /// [imageUrls] 表示する画像URLのリスト
   /// [initialIndex] 初期表示する画像のインデックス
@@ -67,40 +67,67 @@ class ImageViewer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.transparent,
-      body: PageView.builder(
-        controller: PageController(initialPage: initialIndex),
-        itemCount: imageUrls.length,
-        itemBuilder: (context, index) {
-          return GestureDetector(
-            onTap: () => Navigator.of(context).pop(),
-            child: Container(
-              color: Colors.transparent,
-              child: Center(
-                child: Hero(
-                  tag: '${heroTagPrefix}_$index',
-                  child: InteractiveViewer(
-                    minScale: 1.0,
-                    maxScale: 5.0,
-                    child: CachedNetworkImage(
-                      imageUrl: imageUrls[index],
-                      fit: BoxFit.contain,
-                      placeholder: (context, url) => const Center(
-                        child: CircularProgressIndicator(
-                          color: Colors.white,
+      body: Stack(
+        children: [
+          PageView.builder(
+            controller: PageController(initialPage: initialIndex),
+            itemCount: imageUrls.length,
+            itemBuilder: (context, index) {
+              return GestureDetector(
+                onTap: () => Navigator.of(context).pop(),
+                child: Container(
+                  color: Colors.transparent,
+                  child: Center(
+                    child: Hero(
+                      tag: '${heroTagPrefix}_$index',
+                      child: InteractiveViewer(
+                        minScale: 1.0,
+                        maxScale: 5.0,
+                        child: CachedNetworkImage(
+                          imageUrl: imageUrls[index],
+                          fit: BoxFit.contain,
+                          placeholder: (context, url) => const Center(
+                            child: CircularProgressIndicator(
+                              color: Colors.white,
+                            ),
+                          ),
+                          errorWidget: (context, url, error) => const Icon(
+                            Icons.error,
+                            color: Colors.white,
+                            size: 48,
+                          ),
                         ),
-                      ),
-                      errorWidget: (context, url, error) => const Icon(
-                        Icons.error,
-                        color: Colors.white,
-                        size: 48,
                       ),
                     ),
                   ),
                 ),
+              );
+            },
+          ),
+          // 閉じるボタン（右上）
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 16,
+            right: 16,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: Colors.white.withOpacity(0.3),
+                  width: 1,
+                ),
+              ),
+              child: IconButton(
+                icon: const Icon(
+                  Icons.close,
+                  color: Colors.white,
+                  size: 24,
+                ),
+                onPressed: () => Navigator.of(context).pop(),
               ),
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/components/my_tweets_section.dart
+++ b/lib/presentation/components/my_tweets_section.dart
@@ -159,6 +159,7 @@ class MyTweetsSectionState extends ConsumerState<MyTweetsSection> {
                       tweetId: tweet.id,
                       content: tweet.content,
                       mediaUrls: tweet.mediaUrls,
+                      contextPrefix: 'my_tweets', // マイツイート画面用
                     );
                   },
                 ),

--- a/lib/presentation/components/tweet/favorite_tweets_section.dart
+++ b/lib/presentation/components/tweet/favorite_tweets_section.dart
@@ -194,6 +194,7 @@ class FavoriteTweetsSectionState extends ConsumerState<FavoriteTweetsSection> {
                       content: favoriteUserTweet.content,
                       mediaUrls: favoriteUserTweet.mediaUrls,
                       tweetId: favoriteUserTweet.id,
+                      contextPrefix: 'favorite', // お気に入りツイート画面用
                       // ブロック成功時の処理：ツイート一覧を更新
                       onBlockSuccess: () async {
                         // ツイート一覧を再取得（ブロックしたユーザーのツイートは除外される）

--- a/lib/presentation/components/tweet/general_tweets_section.dart
+++ b/lib/presentation/components/tweet/general_tweets_section.dart
@@ -87,6 +87,7 @@ class GeneralTweetsSectionState extends ConsumerState<GeneralTweetsSection> {
             content: generalTweet.content,
             mediaUrls: generalTweet.mediaUrls,
             tweetId: generalTweet.id,
+            contextPrefix: 'general', // 一般ツイート画面用
             // ブロック成功時の処理：ツイート一覧を更新
             onBlockSuccess: () async {
               // ツイート一覧を再取得（ブロックしたユーザーのツイートは除外される）

--- a/lib/presentation/components/tweet/gym_tweets_section.dart
+++ b/lib/presentation/components/tweet/gym_tweets_section.dart
@@ -187,6 +187,7 @@ class GymTweetsSectionState extends ConsumerState<GymTweetsSection> {
             content: tweet.content,
             mediaUrls: tweet.mediaUrls,
             tweetId: tweet.id,
+            contextPrefix: 'gym', // ジムツイート画面用
           );
         },
       ),

--- a/lib/presentation/components/user/favorite_user_card.dart
+++ b/lib/presentation/components/user/favorite_user_card.dart
@@ -54,7 +54,7 @@ class FavoriteUserCard extends ConsumerWidget {
           children: [
             // ユーザーアイコン
             Hero(
-              tag: 'favorite_user_icon_${user.id}',
+              tag: 'favorite_icon_${user.id}',
               child: ClipOval(
                 child: _buildUserIcon(),
               ),

--- a/lib/presentation/components/user/other_user_tweets_section.dart
+++ b/lib/presentation/components/user/other_user_tweets_section.dart
@@ -151,6 +151,7 @@ class _OtherUserTweetsSectionState extends ConsumerState<OtherUserTweetsSection>
             content: tweet.content,
             mediaUrls: tweet.mediaUrls,
             tweetId: tweet.id,
+            contextPrefix: 'profile', // プロフィール画面用のプレフィックス
           );
         },
       ),

--- a/lib/presentation/components/user/user_avatar.dart
+++ b/lib/presentation/components/user/user_avatar.dart
@@ -42,7 +42,7 @@ class UserAvatar extends StatelessWidget {
           GestureDetector(
             onTap: onTap ?? (userImageUrl != null ? () => _showImageDialog(context) : null),
             child: Hero(
-              tag: heroTag ?? 'user_avatar_${userName.hashCode}',
+              tag: heroTag ?? 'avatar_icon_${userName.hashCode}',
               child: ClipOval(
                 child: _buildProfileImage(),
               ),
@@ -123,7 +123,7 @@ class UserAvatar extends StatelessWidget {
             ),
             Center(
               child: Hero(
-                tag: heroTag ?? 'user_avatar_${userName.hashCode}',
+                tag: heroTag ?? 'avatar_icon_${userName.hashCode}',
                 child: InteractiveViewer(
                   minScale: 1.0,
                   maxScale: 20.0,

--- a/lib/presentation/components/user/user_logo_and_name.dart
+++ b/lib/presentation/components/user/user_logo_and_name.dart
@@ -38,17 +38,12 @@ class UserLogoAndName extends StatelessWidget {
                   context: context,
                   imageUrls: [userLogo!],
                   initialIndex: 0,
-                  heroTagPrefix: heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}',
+                  heroTagPrefix: 'profile_icon_${userId ?? userName.hashCode}',
                 );
               }
             },
             child: Hero(
-              // 元の実装（Heroアニメーションが効かない）
-              // tag:
-              //     heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}',
-              // 新しい実装（ImageViewer側と合わせるため_0を付加）
-              tag:
-                  '${heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}'}_0',
+              tag: 'profile_icon_${userId ?? userName.hashCode}_0',
               child: ClipOval(
                 child: (_isValidUrl(userLogo))
                     ? Image.network(

--- a/lib/presentation/components/user/user_logo_and_name.dart
+++ b/lib/presentation/components/user/user_logo_and_name.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../common/image_viewer.dart';
 
 /// ■ クラス
 /// - マイページで(他ユーザーも含む),アイコンとユーザー名を表示する
@@ -33,51 +34,21 @@ class UserLogoAndName extends StatelessWidget {
           GestureDetector(
             onTap: () {
               if (_isValidUrl(userLogo)) {
-                showGeneralDialog(
+                ImageViewer.show(
                   context: context,
-                  barrierDismissible: true,
-                  barrierLabel: "ProfileImageDialog",
-                  barrierColor: Colors.white.withOpacity(0.8),
-                  transitionDuration: const Duration(milliseconds: 300),
-                  pageBuilder: (context, _, __) {
-                    return Stack(
-                      children: [
-                        GestureDetector(
-                          onTap: () => Navigator.of(context).pop(),
-                          child: Container(
-                            color: Colors.transparent,
-                          ),
-                        ),
-                        Center(
-                          child: Hero(
-                            tag: heroTag ??
-                                'user_icon_default_${userId ?? userName.hashCode}',
-                            child: InteractiveViewer(
-                              minScale: 1.0,
-                              maxScale: 20.0,
-                              child: Image.network(
-                                userLogo!,
-                                fit: BoxFit.contain,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                  transitionBuilder:
-                      (context, animation, secondaryAnimation, child) {
-                    return FadeTransition(
-                      opacity: animation,
-                      child: child,
-                    );
-                  },
+                  imageUrls: [userLogo!],
+                  initialIndex: 0,
+                  heroTagPrefix: heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}',
                 );
               }
             },
             child: Hero(
+              // 元の実装（Heroアニメーションが効かない）
+              // tag:
+              //     heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}',
+              // 新しい実装（ImageViewer側と合わせるため_0を付加）
               tag:
-                  heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}',
+                  '${heroTag ?? 'user_icon_default_${userId ?? userName.hashCode}'}_0',
               child: ClipOval(
                 child: (_isValidUrl(userLogo))
                     ? Image.network(

--- a/lib/presentation/pages/block_list_page.dart
+++ b/lib/presentation/pages/block_list_page.dart
@@ -359,7 +359,7 @@ class _BlockedUserTileState extends ConsumerState<_BlockedUserTile> {
           children: [
             // ユーザーアイコン
             Hero(
-              tag: 'blocked_user_icon_${widget.blockedUser.userId}',
+              tag: 'blocked_icon_${widget.blockedUser.userId}',
               child: ClipOval(
                 child: widget.buildUserIcon(),
               ),

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -54,6 +54,7 @@ class SettingsPage extends ConsumerWidget {
         _buildAboutSection(context),
         const SizedBox(height: 24),
         _buildDangerZoneSection(context, ref),
+        const SizedBox(height: 36),
       ],
     );
   }


### PR DESCRIPTION
## 概要
写真を閉じるボタンを追加（実装）
ページ遷移間で写真ホバーするバグを修正

## 変更内容
### フロントエンド
- アイコン写真，ツイート投稿付帯写真をタップ時，写真を閉じるボタンを実装
- Heroタグをそれぞれのウィジェットで一意になるように修正して，写真ホバー様動作が発生するのを修正

### 補足：Hero Tag命名規則
- {context}_{component_type}_{unique_id}_{index}
  - context: 画面コンテキスト（general, profile, my_tweets等）
  - component_type: コンポーネント種類（tweet_media, profile_icon等）
  - unique_id: 一意識別子（userId, tweetId等）
  - index: 複数画像の場合のインデックス